### PR TITLE
Add constraint for generated plugin version

### DIFF
--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -13,6 +13,9 @@
     <requiredProperty key="signing_support">
       <defaultValue>false</defaultValue>
     </requiredProperty>
+    <requiredProperty key="version">
+        <defaultValue>1.0.0-SNAPSHOT</defaultValue>
+    </requiredProperty>
   </requiredProperties>
   <fileSets>
     <fileSet encoding="UTF-8"  filtered="true">


### PR DESCRIPTION
Eclipse Plugin [version must contain](https://wiki.eclipse.org/Version_Numbering) **3** digits, not 2. This PR makes default version **1.0.0**-SNAPSHOT instead of 1.0-SNAPSHOT.

Fixes [this issue](https://github.com/open-archetypes/tycho-eclipse-plugin-archetype/issues/21) and makes unnecessary [this PR](https://github.com/open-archetypes/tycho-eclipse-plugin-archetype/pull/25).